### PR TITLE
Add tests for findNextPipePosition

### DIFF
--- a/findNextPipePosition.js
+++ b/findNextPipePosition.js
@@ -1,0 +1,80 @@
+const PIPE_PATHS = {
+  horizontal: { left: true, right: true, top: false, bottom: false },
+  vertical: { left: false, right: false, top: true, bottom: true },
+  'corner-tl': { left: true, right: false, top: true, bottom: false },
+  'corner-tr': { left: false, right: true, top: true, bottom: false },
+  'corner-bl': { left: true, right: false, top: false, bottom: true },
+  'corner-br': { left: false, right: true, top: false, bottom: true },
+  cross: { left: true, right: true, top: true, bottom: true }
+};
+
+function canConnect(move, nextPipe) {
+  const nextConnections = PIPE_PATHS[nextPipe];
+  if (!nextConnections) return false;
+  return (
+    (move.direction === 'left' && nextConnections.right) ||
+    (move.direction === 'right' && nextConnections.left) ||
+    (move.direction === 'top' && nextConnections.bottom) ||
+    (move.direction === 'bottom' && nextConnections.top)
+  );
+}
+
+function findNextPipePosition(grid, currentX, currentY, previousX, previousY) {
+  const GRID_SIZE = grid.length;
+  const currentPipe = grid[currentY] && grid[currentY][currentX];
+  if (!currentPipe) return null;
+
+  const connections = PIPE_PATHS[currentPipe];
+  const possibleMoves = [];
+
+  if (connections.left && currentX > 0) {
+    possibleMoves.push({ x: currentX - 1, y: currentY, direction: 'left' });
+  }
+  if (connections.right && currentX < GRID_SIZE - 1) {
+    possibleMoves.push({ x: currentX + 1, y: currentY, direction: 'right' });
+  }
+  if (connections.top && currentY > 0) {
+    possibleMoves.push({ x: currentX, y: currentY - 1, direction: 'top' });
+  }
+  if (connections.bottom && currentY < GRID_SIZE - 1) {
+    possibleMoves.push({ x: currentX, y: currentY + 1, direction: 'bottom' });
+  }
+
+  const validMoves = possibleMoves.filter(move => {
+    if (previousX === null || previousY === null) return true;
+    return !(move.x === previousX && move.y === previousY);
+  });
+
+  if (currentPipe === 'cross' && previousX !== null && previousY !== null) {
+    const incomingDirection = {
+      x: currentX - previousX,
+      y: currentY - previousY
+    };
+
+    const continueStraight = validMoves.find(move => {
+      const moveDirection = {
+        x: move.x - currentX,
+        y: move.y - currentY
+      };
+      return moveDirection.x === incomingDirection.x && moveDirection.y === incomingDirection.y;
+    });
+
+    if (continueStraight) {
+      const nextPipe = grid[continueStraight.y] && grid[continueStraight.y][continueStraight.x];
+      if (nextPipe && canConnect(continueStraight, nextPipe)) {
+        return { x: continueStraight.x, y: continueStraight.y };
+      }
+    }
+  }
+
+  for (const move of validMoves) {
+    const nextPipe = grid[move.y] && grid[move.y][move.x];
+    if (nextPipe && canConnect(move, nextPipe)) {
+      return { x: move.x, y: move.y };
+    }
+  }
+
+  return null;
+}
+
+module.exports = { findNextPipePosition, PIPE_PATHS };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ai_pipelines",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/findNextPipePosition.test.js
+++ b/tests/findNextPipePosition.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { findNextPipePosition } = require('../findNextPipePosition');
+
+test('moves forward on straight pipe without backtracking', () => {
+  const grid = [
+    ['horizontal', 'horizontal', 'horizontal'],
+    [null, null, null],
+    [null, null, null]
+  ];
+  const result = findNextPipePosition(grid, 1, 0, 0, 0);
+  assert.deepStrictEqual(result, { x: 2, y: 0 });
+});
+
+test('turns correctly on corner pipe', () => {
+  const grid = [
+    [null, 'vertical', null],
+    [null, 'corner-tr', 'horizontal'],
+    [null, null, null]
+  ];
+  const result = findNextPipePosition(grid, 1, 1, 1, 0);
+  assert.deepStrictEqual(result, { x: 2, y: 1 });
+});
+
+test('cross pipe prefers straight path and avoids backtracking', () => {
+  const grid = [
+    [null, null, null],
+    ['horizontal', 'cross', 'horizontal'],
+    [null, 'vertical', null]
+  ];
+  const result = findNextPipePosition(grid, 1, 1, 0, 1);
+  assert.deepStrictEqual(result, { x: 2, y: 1 });
+});


### PR DESCRIPTION
## Summary
- add standalone `findNextPipePosition` helper with pipe connectivity map
- configure Node's built-in test runner and add tests for straight, corner, and cross pipes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fda485920832cb5300ed1677e2747